### PR TITLE
Use Persistent block device naming

### DIFF
--- a/mounts
+++ b/mounts
@@ -1,4 +1,4 @@
 #!/bin/bash
 sudo modprobe zfs
-sudo zpool import hdd-pool
-sudo zpool import ssd-pool
+sudo zpool import -d /dev/disk/by-id hdd-pool
+sudo zpool import -d /dev/disk/by-id ssd-pool


### PR DESCRIPTION
Import by disk id, [best for small pools](https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#selecting-dev-names-when-creating-a-pool-linux).